### PR TITLE
3 add get artifact info usage for dmsapi v3 to get rid of classifier guessing from a filename

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup
 
-__version = "1.4.1"
+__version = "1.5.0"
 
 setup(
     name="oc-dms-mirror",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup
 
-__version = "1.4.0"
+__version = "1.4.1"
 
 setup(
     name="oc-dms-mirror",
@@ -11,7 +11,7 @@ setup(
     long_description="Tool for mirroring DMS artifacts",
     long_description_content_type="text/plain",
     install_requires=[
-        "oc-cdtapi >= 3.10.0",
+        "oc-cdtapi >= 3.11.6",
         "oc-checksumsq >= 10.0.3"
     ],
     packages=["oc_dms_mirror"])


### PR DESCRIPTION
Add artifact properties filling from additional *get_artifact_info* call instead of parsing *fileName* value.
But *fileName* will be still parsed if *get_artifact_info* returns an incomplete data.