### PR TITLE
fix: set deliverable always false

### DIFF
--- a/oc_dms_mirror/dms_mirror.py
+++ b/oc_dms_mirror/dms_mirror.py
@@ -172,7 +172,7 @@ class DmsMirror:
             "ci_type_group_id": component_id,
             "name": component_name,
             "is_standard": "N" if client else "Y",
-            "is_deliverable": True,
+            "is_deliverable": False,
             "regexp": self.generate_ci_regexp(component_id, client),
             "loc_type_id": "NXS",
             "dms_id": component_id,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup
 
-__version = "2.4.0"
+__version = "2.4.1"
 
 setup(
     name="oc-dms-mirror",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Component registration now defaults new components to non-deliverable, giving teams explicit control over when items become deliverable.
- Chores
  - Bumped package version to 2.4.1.

Notes:
- This change affects newly registered components only and helps prevent unintended delivery workflows until explicitly enabled.
- No other functional behavior, dependencies, or documentation were modified in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->