### PR TITLE
feat: add new labels payload and use new VaultAPI structure

### DIFF
--- a/oc_dms_mirror/dms_mirror.py
+++ b/oc_dms_mirror/dms_mirror.py
@@ -186,7 +186,7 @@ class DmsMirror:
     def register_component(self, payload):
         component_id = payload.get("componentVersion").get("component")
         component_name = payload.get("componentVersion").get("displayName")
-        component_labels = payload.get("componentVersion").get("labels")
+        component_labels = payload.get("componentVersion").get("labels", [])
 
         # Component only deliverable if the labels non-deliverable not in component labels
         is_deliverable = False if "non-deliverable" in component_labels else True

--- a/oc_dms_mirror/dms_mirror.py
+++ b/oc_dms_mirror/dms_mirror.py
@@ -186,7 +186,7 @@ class DmsMirror:
     def register_component(self, payload):
         component_id = payload.get("componentVersion").get("component")
         component_name = payload.get("componentVersion").get("displayName")
-        component_labels = payload.get("componentVersion").get("labels", [])
+        component_labels = payload.get("componentVersion").get("labels", ['non-deliverable'])
 
         # Component only deliverable if the labels non-deliverable not in component labels
         is_deliverable = False if "non-deliverable" in component_labels else True

--- a/oc_dms_mirror/dms_mirror.py
+++ b/oc_dms_mirror/dms_mirror.py
@@ -88,9 +88,9 @@ class DmsMirror:
         """
 
         _pg_client = PgAPI.PostgresAPI(
-                root=self._args.pg_url,
-                user=self._args.pg_user,
-                auth=self._args.pg_password)
+                root=self._args.psql_api_url,
+                user=self._args.psql_api_user,
+                auth=self._args.psql_api_password)
 
         return _pg_client
 
@@ -186,6 +186,10 @@ class DmsMirror:
     def register_component(self, payload):
         component_id = payload.get("componentVersion").get("component")
         component_name = payload.get("componentVersion").get("displayName")
+        component_labels = payload.get("componentVersion").get("labels")
+
+        # Component only deliverable if the labels non-deliverable not in component labels
+        is_deliverable = False if "non-deliverable" in component_labels else True
 
         if self.is_component_registered(component_id):
             self.logger.info(f"Component with id [{component_id}] already registered, skipping")
@@ -201,8 +205,8 @@ class DmsMirror:
             "ci_type_group_id": component_id,
             "name": component_name,
             "is_standard": "N" if client else "Y",
-            "is_deliverable": False,
-            "regexp": self.generate_ci_regexp(component_id, client),
+            "is_deliverable": is_deliverable,
+            "regexp": ciregexp,
             "loc_type_id": "NXS",
             "dms_id": component_id,
             "doc_artifactid": component_id,
@@ -598,11 +602,11 @@ class DmsMirror:
         parser.add_argument("--mvn-prefix", dest="mvn_prefix", type=str, help="MVN GroupId prefix for destination",
                             default=vault_api.load_secret("MVN_PREFIX") or "com.example")
         parser.add_argument("--mvn-url", dest="mvn_url", help="MVN URL",
-                            default=vault_api.load_secret("MVN_URL"))
+                            default=vault_api.load_secret("MVN__URL"))
         parser.add_argument("--mvn-user", dest="mvn_user", help="MVN user",
-                            default=vault_api.load_secret("MVN_USER"))
+                            default=vault_api.load_secret("MVN__USER"))
         parser.add_argument("--mvn-password", dest="mvn_password", help="MVN password",
-                            default=vault_api.load_secret("MVN_PASSWORD"))
+                            default=vault_api.load_secret("MVN__PASSWORD"))
         parser.add_argument("--mvn-upload-repo", dest="mvn_upload_repo", help="MVN repository to upload to",
                             default=vault_api.load_secret("MVN_UPLOAD_REPO") or "\x63\x64\x74.wa\x79\x34")
         parser.add_argument("--mvn-download-repo", dest="mvn_download_repo", help="MVN repository to download from",
@@ -610,12 +614,12 @@ class DmsMirror:
 
         # AMQP arguments
         parser.add_argument('--amqp-username', '-l',
-                            help='Queue server connection username', default=vault_api.load_secret('AMQP_USER'))
+                            help='Queue server connection username', default=vault_api.load_secret('AMQP__USER'))
         parser.add_argument('--amqp-password',
-                            help='Queue server connection password', default=vault_api.load_secret('AMQP_PASSWORD'))
+                            help='Queue server connection password', default=vault_api.load_secret('AMQP__PASSWORD'))
         parser.add_argument('--amqp-url', '-u',
                             help='Queue server url in form: amqp://user:pass@host:port/<vhost>[?params]',
-                            default=vault_api.load_secret('AMQP_URL', 'amqp://guest:guest@localhost/'))
+                            default=vault_api.load_secret('AMQP__URL', 'amqp://guest:guest@localhost/'))
         # DMS arguments
         parser.add_argument("--dms-api-version", dest="dms_api_version", type=int,
                             help="DMS REST API version to use", default=3, choices=[2,3])
@@ -623,25 +627,25 @@ class DmsMirror:
                             help="DMS Component Registry URL (necessary for DMS API v2)",
                             default=vault_api.load_secret("DMS_CRS_URL"))
         parser.add_argument("--dms-token", dest="dms_token", type=str, help="DMS authorization token",
-                            default=vault_api.load_secret("DMS_TOKEN"))
+                            default=vault_api.load_secret("DMS__TOKEN"))
         parser.add_argument("--dms-url", dest="dms_url", help="DMS URL",
-                            default=vault_api.load_secret("DMS_URL"))
+                            default=vault_api.load_secret("DMS__URL"))
         parser.add_argument("--dms-user", dest="dms_user", help="DMS user",
-                            default=vault_api.load_secret("DMS_USER"))
+                            default=vault_api.load_secret("DMS__USER"))
         parser.add_argument("--dms-password", dest="dms_password", help="DMS password",
-                            default=vault_api.load_secret("DMS_PASSWORD"))
-        parser.add_argument("--pg-url", dest="pg_url", help="PG URL",
-                            default=vault_api.load_secret("PG_URL"))
-        parser.add_argument("--pg-user", dest="pg_user", help="PG user",
-                            default=vault_api.load_secret("PG_USER"))
-        parser.add_argument("--pg-password", dest="pg_password", help="PG password",
-                            default=vault_api.load_secret("PG_PASSWORD"))
+                            default=vault_api.load_secret("DMS__PASSWORD"))
+        parser.add_argument("--pg-url", dest="psql_api_url", help="PSQL API URL",
+                            default=vault_api.load_secret("PSQL_API__URL"))
+        parser.add_argument("--pg-user", dest="psql_api_user", help="PSQL API user",
+                            default=vault_api.load_secret("PSQL_API__USER"))
+        parser.add_argument("--pg-password", dest="psql_api_password", help="PSQL API password",
+                            default=vault_api.load_secret("PSQL_API__PASSWORD"))
         parser.add_argument("--psql-mq-url", dest="psql_mq_url", help="PSQL MQ URL",
-                            default=vault_api.load_secret("PSQL_MQ_URL"))
+                            default=vault_api.load_secret("PSQL_MQ__URL"))
         parser.add_argument("--psql-mq-user", dest="psql_mq_user", help="PSQL MQ user",
-                            default=vault_api.load_secret("PSQL_MQ_USER"))
+                            default=vault_api.load_secret("PSQL_MQ__USER"))
         parser.add_argument("--psql-mq-password", dest="psql_mq_password", help="PSQL MQ password",
-                            default=vault_api.load_secret("PSQL_MQ_PASSWORD"))
+                            default=vault_api.load_secret("PSQL_MQ__PASSWORD"))
         parser.add_argument("--dms-processes", dest="dms_processes", 
                             help="Processes (threads) to run in parallel",
                             type=int, default=3)

--- a/oc_dms_mirror/tests/test_dms_mirror.py
+++ b/oc_dms_mirror/tests/test_dms_mirror.py
@@ -921,7 +921,7 @@ class DmsMirrorV3TestSuite(DmsMirrorV2TestSuite):
 
     def test_register_component__no_gav_template(self):
         self.dmsmirror.pg_client.get_citypedms_by_dms_id = Mock(
-            return_value=Mock(status_code=200)
+            return_value=Mock(status_code=404)
         )
         self.dmsmirror.pg_client.post_new_component = Mock(
             return_value=Mock(status_code=201)

--- a/oc_dms_mirror/tests/test_dms_mirror.py
+++ b/oc_dms_mirror/tests/test_dms_mirror.py
@@ -6,8 +6,10 @@ import json
 
 import unittest
 import unittest.mock
+from unittest.mock import Mock, call
 from ..dms_mirror import DmsMirror
 from oc_cdtapi.DmsAPI import DmsAPI, DmsAPIv3
+from oc_cdtapi.API import HttpAPIError
 from string import Template
 import re
 from oc_checksumsq.checksums_interface import FileLocation
@@ -39,12 +41,23 @@ class DmsMirrorTestBase(unittest.TestCase):
                 'PSQL_MQ_PASSWORD': 'test_psql_mq_password',
         }
 
+        self.gav_template = {
+            "ci_type": "$component",
+            "tgtGavTemplate": {
+                "notes": "$prefix.ext.release_notes:$component\\$c_hyphen:\\$v:\\$p",
+                "distribution": "$prefix.way4.$client.$component:\\$n\\$c_hyphen:\\$v:\\$p",
+                "report": "$prefix.ext.release_notes:$component\\$c_hyphen:\\$v:\\$p",
+                "documentation": "$prefix.ext.documentation:$component\\$c_hyphen:\\$v:\\$p"
+            }
+        }
+
+
         self.args = unittest.mock.MagicMock()
         self.args.amqp_url = self.env.get('AMQP_URL')
         self.args.amqp_username = self.env.get('AMQP_USER')
         self.args.amqp_password = self.env.get('AMQP_PASSWORD')
         self.args.config_file = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'resources', 'config.json')
-        self.args.gav_template_config_file = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'resources', 'gav_template_config_file.json')
+        self.args.gav_template_config_file = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'resources', 'config.json')
         self.args.mvn_prefix = self.env.get('MVN_PREFIX')
         self.args.mvn_url = self.env.get('MVN_URL')
         self.args.mvn_user = self.env.get('MVN_USER')
@@ -64,6 +77,8 @@ class DmsMirrorTestBase(unittest.TestCase):
         self.dmsmirror._queue_client = unittest.mock.MagicMock()
         self.dmsmirror._psql_mq_client = unittest.mock.MagicMock()
         self.dmsmirror._mvn_client = unittest.mock.MagicMock()
+        self.dmsmirror._gav_template = self.gav_template
+
 
 class DmsMirrorInitTestSuite(DmsMirrorTestBase):
     def test_init(self):
@@ -663,3 +678,271 @@ class DmsMirrorV3TestSuite(DmsMirrorV2TestSuite):
         self.dmsmirror._mvn_client.cat.assert_not_called()
         self.dmsmirror._mvn_client.upload.assert_called_once_with(
                 _tgt_gav, repo=self.args.mvn_upload_repo, data=unittest.mock.ANY, pom=True)
+        
+    def test_process_component_webhook__ok(self):
+        self.dmsmirror.process_artifact = unittest.mock.MagicMock(return_value=None)
+        self.dmsmirror.register_component = unittest.mock.MagicMock(return_value=None)
+
+        payload = {
+            'type': 'PUBLISH_COMPONENT_VERSION',
+            'componentVersion': {
+                'component': 'test-component',
+                'version': '1.0.0',
+                'displayName': 'Test Component',
+                'labels': [],
+                'clientCode': None
+            },
+            'artifacts': [
+                {'artifactId': 'artifact-1'},
+                {'artifactId': 'artifact-2'}
+            ]
+        }
+
+        self.dmsmirror.process_component_webhook(payload=payload)
+        
+        self.dmsmirror.register_component.assert_called_once_with(payload)
+        
+        self.assertEqual(self.dmsmirror.process_artifact.call_count, 2)
+        
+        expected_calls = [
+            call({'artifactId': 'artifact-1'}, 'test-component', '1.0.0'),
+            call({'artifactId': 'artifact-2'}, 'test-component', '1.0.0')
+        ]
+        self.dmsmirror.process_artifact.assert_has_calls(expected_calls)
+
+    def test_process_component_webhook__wrong_event_type(self):
+        self.dmsmirror.process_artifact = unittest.mock.MagicMock()
+        self.dmsmirror.register_component = unittest.mock.MagicMock()
+
+        payload = {
+            'type': 'SOME_OTHER_EVENT',
+            'componentVersion': {
+                'component': 'test-component',
+                'version': '1.0.0'
+            },
+            'artifacts': [{'artifactId': 'artifact-1'}]
+        }
+
+        with self.assertRaises(Exception) as ctx:
+            self.dmsmirror.process_component_webhook(payload=payload)
+
+        self.assertIn("Event type is SOME_OTHER_EVENT", str(ctx.exception))
+
+        self.dmsmirror.register_component.assert_not_called()
+        self.dmsmirror.process_artifact.assert_not_called()
+
+    def test_process_component_webhook__missing_component_version(self):
+        self.dmsmirror.process_artifact = unittest.mock.MagicMock()
+        self.dmsmirror.register_component = unittest.mock.MagicMock()
+
+        payload = {
+            'type': self.dmsmirror.DmsEventType.PUBLISH_COMPONENT_VERSION.value,
+            'artifacts': [{'artifactId': 'artifact-1'}]
+        }
+
+        with self.assertRaises(ValueError) as ctx:
+            self.dmsmirror.process_component_webhook(payload=payload)
+
+        self.assertIn("Missing or invalid componentVersion", str(ctx.exception))
+
+        self.dmsmirror.register_component.assert_not_called()
+        self.dmsmirror.process_artifact.assert_not_called()
+
+    def test_process_component_webhook__component_version_not_dict(self):
+        self.dmsmirror.process_artifact = unittest.mock.MagicMock()
+        self.dmsmirror.register_component = unittest.mock.MagicMock()
+
+        payload = {
+            'type': self.dmsmirror.DmsEventType.PUBLISH_COMPONENT_VERSION.value,
+            'componentVersion': "invalid",
+            'artifacts': [{'artifactId': 'artifact-1'}]
+        }
+
+        with self.assertRaises(ValueError):
+            self.dmsmirror.process_component_webhook(payload=payload)
+
+        self.dmsmirror.register_component.assert_not_called()
+        self.dmsmirror.process_artifact.assert_not_called()
+
+    def test_process_component_webhook__missing_component(self):
+        self.dmsmirror.process_artifact = unittest.mock.MagicMock()
+        self.dmsmirror.register_component = unittest.mock.MagicMock()
+
+        payload = {
+            'type': self.dmsmirror.DmsEventType.PUBLISH_COMPONENT_VERSION.value,
+            'componentVersion': {
+                'version': '1.0.0'
+            },
+            'artifacts': [{'artifactId': 'artifact-1'}]
+        }
+
+        with self.assertRaises(ValueError) as ctx:
+            self.dmsmirror.process_component_webhook(payload=payload)
+
+        self.assertIn("Missing required fields", str(ctx.exception))
+
+        self.dmsmirror.register_component.assert_not_called()
+        self.dmsmirror.process_artifact.assert_not_called()
+
+    def test_process_component_webhook__missing_version(self):
+        self.dmsmirror.process_artifact = unittest.mock.MagicMock()
+        self.dmsmirror.register_component = unittest.mock.MagicMock()
+
+        payload = {
+            'type': self.dmsmirror.DmsEventType.PUBLISH_COMPONENT_VERSION.value,
+            'componentVersion': {
+                'component': 'test-component'
+            },
+            'artifacts': [{'artifactId': 'artifact-1'}]
+        }
+
+        with self.assertRaises(ValueError):
+            self.dmsmirror.process_component_webhook(payload=payload)
+
+        self.dmsmirror.register_component.assert_not_called()
+        self.dmsmirror.process_artifact.assert_not_called()
+
+    def test_process_component_webhook__auto_register_disabled(self):
+        self.dmsmirror._args.auto_register_component = False
+        self.dmsmirror.process_artifact = unittest.mock.MagicMock()
+        self.dmsmirror.register_component = unittest.mock.MagicMock()
+
+        payload = {
+            'type': self.dmsmirror.DmsEventType.PUBLISH_COMPONENT_VERSION.value,
+            'componentVersion': {
+                'component': 'test-component',
+                'version': '1.0.0'
+            },
+            'artifacts': [{'artifactId': 'artifact-1'}]
+        }
+
+        self.dmsmirror.process_component_webhook(payload=payload)
+
+        self.dmsmirror.register_component.assert_not_called()
+        self.dmsmirror.process_artifact.assert_called_once()
+
+    def test_register_component__ok(self):
+        self.dmsmirror.pg_client.get_citypedms_by_dms_id = Mock(side_effect=HttpAPIError(code=404))
+        self.dmsmirror.pg_client.post_new_component = Mock(
+            return_value=Mock(status_code=201)
+        )
+
+        payload = {
+            'type': 'PUBLISH_COMPONENT_VERSION',
+            'componentVersion': {
+                'component': 'test-component',
+                'version': '1.0.0',
+                'displayName': 'Test Component',
+                'labels': [],
+                'clientCode': None
+            },
+            'artifacts': [
+                {'artifactId': 'artifact-1'},
+                {'artifactId': 'artifact-2'}
+            ]
+        }
+
+        self.dmsmirror.register_component(payload=payload)
+
+        self.dmsmirror.pg_client.get_citypedms_by_dms_id.assert_called_once_with("test-component")
+        self.dmsmirror.pg_client.post_new_component.assert_called_once()
+
+        args, kwargs = self.dmsmirror.pg_client.post_new_component.call_args
+        register_payload = args[0]
+
+        self.assertEqual(register_payload["ci_type_id"], "test-component")
+        self.assertEqual(register_payload["name"], "Test Component")
+        self.assertEqual(register_payload["is_standard"], "Y")
+        self.assertEqual(register_payload["is_deliverable"], True)
+        self.assertEqual(register_payload["dms_id"], "test-component")
+
+    def test_register_component__non_deliverable(self):
+        self.dmsmirror.pg_client.get_citypedms_by_dms_id = Mock(side_effect=HttpAPIError(code=404))
+        self.dmsmirror.pg_client.post_new_component = Mock(
+            return_value=Mock(status_code=201)
+        )
+
+        payload = {
+            'type': 'PUBLISH_COMPONENT_VERSION',
+            'componentVersion': {
+                'component': 'test-component',
+                'version': '1.0.0',
+                'displayName': 'Test Component',
+                'labels': ["non-deliverable"],
+                'clientCode': None
+            },
+            'artifacts': [
+                {'artifactId': 'artifact-1'},
+                {'artifactId': 'artifact-2'}
+            ]
+        }
+
+        self.dmsmirror.register_component(payload=payload)
+
+        self.dmsmirror.pg_client.get_citypedms_by_dms_id.assert_called_once_with("test-component")
+        self.dmsmirror.pg_client.post_new_component.assert_called_once()
+
+        args, kwargs = self.dmsmirror.pg_client.post_new_component.call_args
+        register_payload = args[0]
+
+        self.assertEqual(register_payload["ci_type_id"], "test-component")
+        self.assertEqual(register_payload["name"], "Test Component")
+        self.assertEqual(register_payload["is_standard"], "Y")
+        self.assertEqual(register_payload["is_deliverable"], False)
+        self.assertEqual(register_payload["dms_id"], "test-component")
+
+    def test_register_component__component_registered(self):
+        self.dmsmirror.pg_client.get_citypedms_by_dms_id = Mock(
+            return_value=Mock(status_code=200)
+        )
+        self.dmsmirror.pg_client.post_new_component = Mock(
+            return_value=Mock(status_code=201)
+        )
+
+        payload = {
+            'type': 'PUBLISH_COMPONENT_VERSION',
+            'componentVersion': {
+                'component': 'test-component',
+                'version': '1.0.0',
+                'displayName': 'Test Component',
+                'labels': [],
+                'clientCode': None
+            },
+            'artifacts': [
+                {'artifactId': 'artifact-1'},
+                {'artifactId': 'artifact-2'}
+            ]
+        }
+
+        self.dmsmirror.register_component(payload=payload)
+
+        self.dmsmirror.pg_client.get_citypedms_by_dms_id.assert_called_once_with("test-component")
+        self.dmsmirror.pg_client.post_new_component.assert_not_called()
+
+    def test_register_component__no_gav_template(self):
+        self.dmsmirror.pg_client.get_citypedms_by_dms_id = Mock(
+            return_value=Mock(status_code=200)
+        )
+        self.dmsmirror.pg_client.post_new_component = Mock(
+            return_value=Mock(status_code=201)
+        )
+        self.dmsmirror._gav_template = None
+        payload = {
+            'type': 'PUBLISH_COMPONENT_VERSION',
+            'componentVersion': {
+                'component': 'test-component',
+                'version': '1.0.0',
+                'displayName': 'Test Component',
+                'labels': [],
+                'clientCode': None
+            },
+            'artifacts': [
+                {'artifactId': 'artifact-1'},
+                {'artifactId': 'artifact-2'}
+            ]
+        }
+
+        self.dmsmirror.register_component(payload=payload)
+
+        self.dmsmirror.pg_client.get_citypedms_by_dms_id.assert_called_once_with("test-component")
+        self.dmsmirror.pg_client.post_new_component.assert_not_called()

--- a/oc_dms_mirror/tests/test_dms_mirror.py
+++ b/oc_dms_mirror/tests/test_dms_mirror.py
@@ -45,7 +45,7 @@ class DmsMirrorTestBase(unittest.TestCase):
             "ci_type": "$component",
             "tgtGavTemplate": {
                 "notes": "$prefix.ext.release_notes:$component\\$c_hyphen:\\$v:\\$p",
-                "distribution": "$prefix.way4.$client.$component:\\$n\\$c_hyphen:\\$v:\\$p",
+                "distribution": "$prefix.$client.$component:\\$n\\$c_hyphen:\\$v:\\$p",
                 "report": "$prefix.ext.release_notes:$component\\$c_hyphen:\\$v:\\$p",
                 "documentation": "$prefix.ext.documentation:$component\\$c_hyphen:\\$v:\\$p"
             }

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup
 
-__version = "3.3.1"
+__version = "3.3.2"
 
 setup(
     name="oc-dms-mirror",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup
 
-__version = "3.2.0"
+__version = "3.3.0"
 
 setup(
     name="oc-dms-mirror",
@@ -11,7 +11,7 @@ setup(
     long_description="Tool for mirroring DMS artifacts",
     long_description_content_type="text/plain",
     install_requires=[
-        "oc-cdtapi >= 3.29.1",
+        "oc-cdtapi >= 3.33.7",
         "oc-checksumsq >= 10.0.3",
         "flask",
         "gunicorn==23.0.0",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup
 
-__version = "3.3.0"
+__version = "3.3.1"
 
 setup(
     name="oc-dms-mirror",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * PostgreSQL CLI parameters renamed from --pg-* to --psql-api-*
  * Vault/secret key names updated to double-underscore conventions for MVN, AMQP, DMS, PSQL_MQ and PSQL API defaults

* **Improvements**
  * Component deliverability now derived from component labels (label "non-deliverable" toggles status)
  * CLI and configuration surface updated to accept new credential keys

* **Chores**
  * Version bumped to 3.3.2
  * Expanded unit test coverage
  * Dependency updated (oc-cdtapi >= 3.33.7)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->