### PR TITLE
4917

### DIFF
--- a/oc_dms_mirror/dms_mirror.py
+++ b/oc_dms_mirror/dms_mirror.py
@@ -498,8 +498,8 @@ class DmsMirror:
         _location = FileLocation(tgt_gav, "NXS", None)
         if self._args.msg_target == "amqp":
             # Send to RabbitMQ
-            self.logger.info(self.__log_msg(f"About to send queue to mq"))
             self.queue_client.connect()
+            self.logger.info(self.__log_msg(f"About to send queue to mq"))
             resp = self.queue_client.register_file(_location, ci_type, 0)
             self.logger.debug(self.__log_msg(f"Register response: [{resp}]"))
             self.queue_client.disconnect()

--- a/oc_dms_mirror/dms_mirror.py
+++ b/oc_dms_mirror/dms_mirror.py
@@ -495,24 +495,25 @@ class DmsMirror:
         :param str tgt_gav: target gav
         :param str ci_type: ci_type
         """
-        # Send to RabbitMQ
-        self.logger.info(self.__log_msg(f"About to send queue to mq"))
-        self.queue_client.connect()
         _location = FileLocation(tgt_gav, "NXS", None)
-        resp = self.queue_client.register_file(_location, ci_type, 0)
-        self.logger.debug(self.__log_msg(f"Register response: [{resp}]"))
-        self.queue_client.disconnect()
-
-        # Send to PSQL MQ
-        self.logger.info(self.__log_msg(f"About to send queue to psql"))
-        params = {
-            "location": _location,
-            "citype": ci_type,
-            "depth": 0
-        }
-        message = self.psql_mq_client.compose_message('register_file', params)
-        self.logger.debug(self.__log_msg('Composed message: [%s]' % message))
-        self.psql_mq_client.enqueue_message('cdt.dlartifacts.input', message)
+        if self._args.msg_target == "amqp":
+            # Send to RabbitMQ
+            self.logger.info(self.__log_msg(f"About to send queue to mq"))
+            self.queue_client.connect()
+            resp = self.queue_client.register_file(_location, ci_type, 0)
+            self.logger.debug(self.__log_msg(f"Register response: [{resp}]"))
+            self.queue_client.disconnect()
+        else:
+            # Send to PSQL MQ
+            self.logger.info(self.__log_msg(f"About to send queue to psql"))
+            params = {
+                "location": _location,
+                "citype": ci_type,
+                "depth": 0
+            }
+            message = self.psql_mq_client.compose_message('register_file', params)
+            self.logger.debug(self.__log_msg('Composed message: [%s]' % message))
+            self.psql_mq_client.enqueue_message('cdt.dlartifacts.input', message)
 
     def _copy_artifact(self, component, version, artifact, tgt_gav):
         """
@@ -657,6 +658,7 @@ class DmsMirror:
         parser.add_argument("--always-enqueue", dest="always_enqueue",
                             help="Enqueue if artifact exists",
                             action="store_true", default=False)
+        parser.add_argument("--msg-target", dest="msg_target", help="amqp|db message target", default="amqp")
 
         # CITYPE properties
         parser.add_argument("--ci-type-release-notes", dest="ci_type_release_notes",

--- a/oc_dms_mirror/dms_mirror.py
+++ b/oc_dms_mirror/dms_mirror.py
@@ -658,7 +658,7 @@ class DmsMirror:
         parser.add_argument("--always-enqueue", dest="always_enqueue",
                             help="Enqueue if artifact exists",
                             action="store_true", default=False)
-        parser.add_argument("--msg-target", dest="msg_target", help="amqp|db message target", default="amqp")
+        parser.add_argument("--msg-target", dest="msg_target", help="amqp|db message target", default="amqp", choices=["amqp", "db"])
 
         # CITYPE properties
         parser.add_argument("--ci-type-release-notes", dest="ci_type_release_notes",

--- a/oc_dms_mirror/tests/test_dms_mirror.py
+++ b/oc_dms_mirror/tests/test_dms_mirror.py
@@ -70,6 +70,7 @@ class DmsMirrorTestBase(unittest.TestCase):
         self.args.psql_mq_url = self.env.get('PSQL_MQ_URL')
         self.args.psql_mq_user = self.env.get('PSQL_MQ_USER')
         self.args.psql_mq_password = self.env.get('PSQL_MQ_PASSWORD')
+        self.args.msg_target = 'amqp'
         self.args.ci_type_documentation = 'DOCS'
         self.args.ci_type_release_notes = 'RELEASENOTES'
         self.args.always_enqueue = False
@@ -399,7 +400,8 @@ class DmsMirrorV2TestSuite(DmsMirrorTestBase):
         self.dmsmirror._mvn_client.upload.assert_called_once_with(
                 _tgt_gav, repo=self.args.mvn_upload_repo, data=unittest.mock.ANY, pom=True)
 
-    def test_register_artifact(self):
+    def test_register_artifact_amqp(self):
+        self.args.msg_target = 'amqp'
         _tgt_gav = f"{self.args.mvn_prefix}.target:artifact:1:pkg"
         _ci_type = "CITYPE"
 
@@ -412,6 +414,21 @@ class DmsMirrorV2TestSuite(DmsMirrorTestBase):
         self.dmsmirror._queue_client.register_file.assert_called_once_with(
                 FileLocation(_tgt_gav, "NXS", None), _ci_type, 0)
         self.dmsmirror._queue_client.disconnect.assert_called_once()
+
+        mock_params = {
+            "location": FileLocation(_tgt_gav, "NXS", None),
+            "citype": _ci_type,
+            "depth": 0
+        }
+    
+    def test_register_artifact_db(self):
+        _tgt_gav = f"{self.args.mvn_prefix}.target:artifact:1:pkg"
+        _ci_type = "CITYPE"
+        self.args.msg_target='db'
+        mock_message = ["register_file", [[_tgt_gav, "NXS", None], _ci_type, 0], {}]
+        self.dmsmirror._psql_mq_client.compose_message.return_value = mock_message
+
+        self.dmsmirror._register_artifact(_tgt_gav, _ci_type)
 
         mock_params = {
             "location": FileLocation(_tgt_gav, "NXS", None),

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup
 
-__version = "3.4.0"
+__version = "3.5.0"
 
 setup(
     name="oc-dms-mirror",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup
 
-__version = "3.5.0"
+__version = "3.5.1"
 
 setup(
     name="oc-dms-mirror",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup
 
-__version = "3.5.1"
+__version = "3.5.2"
 
 setup(
     name="oc-dms-mirror",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new option to choose which message queue receives artifact registration updates.

* **Bug Fixes**
  * Artifact registration now sends messages to only the selected queue, avoiding duplicate dispatches.

* **Tests**
  * Expanded coverage for both queue-target paths to verify artifact registration works as expected.

* **Chores**
  * Updated the package version to 3.5.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->